### PR TITLE
Add test on-call rotation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,14 +46,14 @@ resource "pagerduty_tag_assignment" "tfprov_issue780_team_tag_whatever" {
 locals {
   team = "Test Team"
   members = [
-    "bogus1@pagerduty.com",
-    "bogus2@pagerduty.com",
-    "bogus3@pagerduty.com",
-    "bogus4@pagerduty.com",
-    "bogus5@pagerduty.com",
+    "bogus1@pd.test",
+    "bogus2@pd.test",
+    "bogus3@pd.test",
+    "bogus4@pd.test",
+    "bogus5@pd.test",
   ]
-  start = "2023-11-27T14:30:00-07:00"
-  manager = "bogus1@pagerduty.com"
+  start   = "2023-11-27T14:30:00-07:00"
+  manager = "bogus1@pd.test"
 }
 
 resource "pagerduty_team" "default" {

--- a/main.tf
+++ b/main.tf
@@ -42,3 +42,63 @@ resource "pagerduty_tag_assignment" "tfprov_issue780_team_tag_whatever" {
   entity_type = "teams"
   entity_id   = pagerduty_team.tfprov_issue780_team.id
 }
+
+locals {
+  team = "Test Team"
+  members = [
+    "bogus1@pagerduty.com",
+    "bogus2@pagerduty.com",
+    "bogus3@pagerduty.com",
+    "bogus4@pagerduty.com",
+    "bogus5@pagerduty.com",
+  ]
+  start = "2023-11-27T14:30:00-07:00"
+  manager = "bogus1@pagerduty.com"
+}
+
+resource "pagerduty_team" "default" {
+  name = local.team
+}
+
+data "pagerduty_user" "team" {
+  for_each = toset(local.members)
+  email    = each.key
+}
+
+data "pagerduty_user" "manager" {
+  email = local.manager
+}
+
+resource "pagerduty_schedule" "default" {
+  name      = "${local.team} schedule"
+  time_zone = "America/Los_Angeles"
+
+  layer {
+    name                         = "${local.team} Ops Leads"
+    start                        = local.start
+    rotation_virtual_start       = local.start
+    rotation_turn_length_seconds = 60 * 60 * 24 * 7
+    users                        = [for member in local.members : data.pagerduty_user.team[member].id]
+  }
+  teams = [pagerduty_team.default.id]
+}
+
+resource "pagerduty_escalation_policy" "default" {
+  name  = "${local.team} Escalation Policy"
+  teams = [pagerduty_team.default.id]
+
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "schedule_reference"
+      id   = pagerduty_schedule.default.id
+    }
+  }
+  rule {
+    escalation_delay_in_minutes = 10
+    target {
+      type = "user_reference"
+      id   = data.pagerduty_user.manager.id
+    }
+  }
+}


### PR DESCRIPTION
Our suspicion is that adding a bunch of user lookups is what triggers rate limits.

- Will you edit this PR to add valid members?
- You can test the theory by adding a ridiculous number of members to the on-call rotation